### PR TITLE
add workflow

### DIFF
--- a/.github/workflows/flatpak_py_editor.yml
+++ b/.github/workflows/flatpak_py_editor.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+name: CI
+jobs:
+  flatpak:
+    name: "Flatpak"
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-47
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v4
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      with:
+        bundle: LibrePythonista_PyEditor.flatpak
+        manifest-path: io.github.amourspirit.LibrePythonista_PyEditor.yml
+        cache-key: flatpak-builder-${{ github.sha }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration (CI) using Flatpak for the `LibrePythonista_PyEditor` project. The key changes include the addition of a new YAML file that defines the CI workflow.

CI workflow setup:

* [`.github/workflows/flatpak_py_editor.yml`](diffhunk://#diff-adf807b61ab66c44c84b63d33d8816a20563efa653ee3752462d8a543fb5f73fR1-R19): Added a new workflow configuration that triggers on pushes to the `main` branch and on pull requests. The workflow is named "CI" and includes a job named "Flatpak" that runs on `ubuntu-latest` using a specified container image. The steps include checking out the repository and using Flatpak to build the project.