### PR TITLE
add upload step for Flatpak artifact in workflow

### DIFF
--- a/.github/workflows/flatpak_py_editor.yml
+++ b/.github/workflows/flatpak_py_editor.yml
@@ -17,3 +17,8 @@ jobs:
         bundle: LibrePythonista_PyEditor.flatpak
         manifest-path: io.github.amourspirit.LibrePythonista_PyEditor.yml
         cache-key: flatpak-builder-${{ github.sha }}
+    - name: Upload Flatpak
+      uses: actions/upload-artifact@v3
+      with:
+        name: LibrePythonista_PyEditor.flatpak
+        path: LibrePythonista_PyEditor.flatpak


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/flatpak_py_editor.yml` file. The change adds a step to upload the Flatpak artifact using the `actions/upload-artifact@v3` action.

* [`.github/workflows/flatpak_py_editor.yml`](diffhunk://#diff-adf807b61ab66c44c84b63d33d8816a20563efa653ee3752462d8a543fb5f73fR20-R24): Added a new step to upload the Flatpak artifact.