### PR TITLE
add CI workflow for Flatpak release automation

### DIFF
--- a/.github/workflows/flatpak_py_editor_release.yml
+++ b/.github/workflows/flatpak_py_editor_release.yml
@@ -1,0 +1,45 @@
+on:
+  push:
+    tags:
+      - 'release*'
+name: CI
+jobs:
+  flatpak:
+    name: "Flatpak"
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-47
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v4
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      with:
+        bundle: LibrePythonista_PyEditor.flatpak
+        manifest-path: io.github.amourspirit.LibrePythonista_PyEditor.yml
+        cache-key: flatpak-builder-${{ github.sha }}
+    - name: Download Artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: LibrePythonista_PyEditor-x86_64.zip
+        path: .
+    - name: Unzip Artifact
+      run: unzip LibrePythonista_PyEditor-x86_64.zip
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+     - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: LibrePythonista_PyEditor.flatpak
+        asset_name: LibrePythonista_PyEditor.flatpak
+        asset_content_type: application/vnd.flatpak


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the release process for the Flatpak package of the PyEditor project. The workflow is triggered by pushing tags that start with 'release' and includes steps for building the Flatpak package, downloading and unzipping artifacts, creating a release, and uploading the release asset.

New GitHub Actions workflow:

* [`.github/workflows/flatpak_py_editor_release.yml`](diffhunk://#diff-baa77846ded0057f0015f04d8dd078e8bec8d669d41d5d32d0e256c74b778b28R1-R45): Added a new workflow to automate the release process for the Flatpak package of the PyEditor project. The workflow includes steps for building the Flatpak package, downloading and unzipping artifacts, creating a release, and uploading the release asset.